### PR TITLE
Implement a first attempt of meditation stages calculation algorithm:

### DIFF
--- a/oscserver/server.py
+++ b/oscserver/server.py
@@ -1,14 +1,24 @@
 import argparse
 import logging
+import numpy as np
 import socketserver
 import sys
+import signal
 
 from pythonosc.osc_bundle import OscBundle
 from pythonosc.osc_message import OscMessage
+from collections import deque
+from statsmodels.tsa import arima_model
+from threading import Thread, Lock, Event
 
 from rabbit_controller import RabbitController
 
-# import RabbitController
+QUEUE_SIZE = 300  # band powers are calculated at 10hz, storing a 30 seconds worth of data in dequeue
+
+EMIT_STAGE_PERIOD_SECONDS = 3 * 60  # evaluating stages every 3 minutes
+ARIMA_PARAMS = (4, 0, 1)
+LOWER_THRESHOLD = -0.04
+UPPER_THRESHOLD = 0.01
 
 logger = logging.getLogger(__name__)
 
@@ -32,35 +42,15 @@ class OscUDPHandler(socketserver.BaseRequestHandler):
                 else OscMessage(dgram)
         logger.info('{address} {params}'.format(address=message.address, 
                                                 params=message.params))
-        if(message.address == '/muse/elements/alpha_absolute'):
-            logger.info("ALPHA: " + repr(message.params))
-            server.alpha = message.params
-        elif(message.address == '/muse/elements/beta_absolute'):
-            logger.info("BETA:  " + repr(message.params))
-            server.beta = message.params
-        elif(message.address == '/muse/elements/gamma_absolute'):
-            logger.info("GAMMA: " + repr(message.params))
-            server.gamma = message.params
-        elif(message.address == '/muse/elements/delta_absolute'):
-            logger.info("DELTA: " + repr(message.params))
-            server.delta = message.params
-        elif(message.address == '/muse/elements/theta_absolute'):
-            logger.info("THETA: " + repr(message.params))
-            server.theta = message.params
-
-            # ALL 5 values have been received
-            # [>] update the meditation_state
-            server.meditation_state = server.get_meditation_state()
-
-            # Send them to the RabbitMQ bus.
-            server.send_eegdata()
-
-            # SEND Meditation state level IF changed
-            if(server.previous_state != server.meditation_state):
-                server.previous_state = server.meditation_state
-                server.send_state()
-
-
+        if message.address == '/muse/elements/alpha_absolute':
+            print('got alpha ' + str(message.params))
+            self.server.queue.append(np.mean(message.params[1:3]))  # storing mean value of abs_alpha in
+            #  channels 2 and 3
+        elif message.address == '/muse/elements/blink':
+            self.server.increment_blink()
+        elif message.address == '/muse/acc':
+            pass
+            # think how to store accelerometer data, we'll need it to detect if person moved too much
 
 
 class OscUDPServer(socketserver.UDPServer):
@@ -71,50 +61,47 @@ class OscUDPServer(socketserver.UDPServer):
 class ThreadingOscUDPServer(socketserver.ThreadingMixIn, OscUDPServer):
 
     def __init__(self, *args, **kwargs):
-        # init EEG values
-        self.alpha = [0.0] * 4
-        self.beta =  [0.0] * 4
-        self.gamma = [0.0] * 4
-        self.delta = [0.0] * 4
-        self.theta = [0.0] * 4
-        self.blink = [0]
-        self.previous_state = None
-        self.meditation_state = 1
-        # init rabbitMQ connection
-        self.rabbit = RabbitController('localhost', 5672, 'guest', 'guest', '/')
         super().__init__(*args, **kwargs)
-    
-    # send values to the bus
-    def send_eegdata(self):
-        allvalues = self.alpha + self.beta + self.gamma + self.delta + self.theta \
-                  + self.blink + [self.meditation_state]
-        self.rabbit.publish_eegdata(allvalues)
-        print("EEGDATA SENT:  " + repr(allvalues))
+        signal.signal(signal.SIGINT, self._signal_handler)
+        self.rabbit = RabbitController('localhost', 5672, 'guest', 'guest', '/')
+        self.queue = deque(maxlen=QUEUE_SIZE)  # we only use append, therefore no need in queue.Queue
+        self.blink_events = 0  # counter of blink events
+        self.state = None
+        self.lock = Lock()
+        self._stop = Event()
+        self._timer_thread = None
+        self.start_emitting_state_messages()
 
-    # send values to the bus
-    def send_state(self):
-        self.rabbit.publish_state(self.meditation_state)
-        print("STATE SENT:  " + repr(self.meditation_state))
+    def increment_blink(self):
+        with self.lock:
+            self.blink_events += 1
 
-    # return a value from 0 (low) to 1 (deep meditation)
-    # based on the waves data (timeless data)
-    def get_meditation_state(self):
-        meditate = 0
-        # (coeff = 5) main   values are forehead alpha and forehead theta
-        meditate = meditate + (self.alpha[1] * 5) + (self.alpha[2] * 5)
-        meditate = meditate + (self.theta[1] * 5) + (self.theta[2] * 5)
-        # (coeff = 2) second values are frontal alpha & theta coherence
-        meditate = meditate + (1 - abs(self.alpha[1] - self.theta[1])) * 2
-        meditate = meditate + (1 - abs(self.alpha[2] - self.theta[2])) * 2
-        # (coeff = 1) third  values are headside alpha and headside theta
-        meditate = meditate + (self.alpha[0] * 1) + (self.alpha[3] * 1)
-        meditate = meditate + (self.theta[0] * 1) + (self.theta[3] * 1)
-        
-        meditate /= 28.  # 5+5+5+5 + 2+2 + 1+1+1+1
-        if(meditate < 0): meditate = 0
-        if(meditate > 1): meditate = 1        
-        # value between 1 and 5
-        return 1 + int(round(meditate * 4, 0))
+    def _signal_handler(self, _, unused_frame):
+        self._stop.set()
+
+    def start_emitting_state_messages(self):
+        self.state = 1
+        self.rabbit.publish_state(self.state)
+        Thread(target=self.predict_next_level, daemon=True).start()
+
+    def predict_next_level(self):
+        while not self._stop.is_set():
+            self._stop.wait(EMIT_STAGE_PERIOD_SECONDS)
+            data = np.array(self.queue, dtype=np.float64)
+            model = arima_model.ARIMA(data, order=ARIMA_PARAMS)
+            model = model.fit(disp=0)
+            forecast = model.predict(start=1, end=20)
+            data_filtered = data[np.where(np.logical_and(np.greater_equal(data, np.percentile(data, 5)),
+                                                         np.less_equal(data, np.percentile(data, 95))))]
+            mean_diff = np.mean(forecast) - np.mean(data_filtered)
+            # add more logic there considering movement and blinks
+            if mean_diff > UPPER_THRESHOLD:
+                self.state = min(self.state + 1, 5)
+            elif mean_diff < LOWER_THRESHOLD:
+                self.state = max(self.state - 1, 1)
+            self.rabbit.publish_state(self.state)
+            with self.lock:
+                self.blink_events = 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1) Always start with the first stage
2) Every 3 minutes calculate the direction of trend over last 30 seconds for frontal alpha, if it raises consistently => increment stage, if it declines => decrement stage or leave it at 1.

I removed raw eeg posting to message queue, is it still needed for something?

(to tune this thing further you may change EMIT_STAGE_PERIOD_SECONDS that defines recalculation period, or QUEUE_SIZE that controls amount of data to calculate trend, 600 samples = 1 minute of data)